### PR TITLE
Feature: Support fill page component (no dimensions)

### DIFF
--- a/src/component/component.js
+++ b/src/component/component.js
@@ -29,8 +29,18 @@ export let components = {};
 export class Component {
 
     constructor(options = {}) {
-        this.validate(options);
 
+        if (!options.dimensions || !(typeof options.dimensions === 'object')) {
+
+            options.dimensions = {
+                width : 0,
+                height : 0
+            };
+
+        }
+        
+        this.validate(options);
+        
         // The tag name of the component. Used by some drivers (e.g. angular) to turn the component into an html element,
         // e.g. <my-component>
 

--- a/src/component/component.js
+++ b/src/component/component.js
@@ -179,10 +179,11 @@ export class Component {
             throw new Error(`Invalid options.tag: ${options.tag}`);
         }
 
-        if (!options.dimensions || !(typeof options.dimensions === 'object')) {
+    /*    if (!options.dimensions || !(typeof options.dimensions === 'object')) {
             throw new Error(`[${options.tag}] Expected options.dimensions to be an object`);
         }
-
+    */
+        
         if (typeof options.dimensions.width !== 'number') {
             throw new Error(`[${options.tag}] Expected options.dimensions.width to be a number`);
         }

--- a/src/component/component.js
+++ b/src/component/component.js
@@ -30,17 +30,19 @@ export class Component {
 
     constructor(options = {}) {
 
-        if (!options.dimensions || !(typeof options.dimensions === 'object')) {
 
-            options.dimensions = {
-                width : 0,
-                height : 0
-            };
-
-        }
         
         this.validate(options);
-        
+
+        if (options.dimensions) {
+            if (typeof options.dimensions.width !== 'number') {
+                throw new Error(`[${options.tag}] Expected options.dimensions.width to be a number`);
+            }
+
+            if (typeof options.dimensions.height !== 'number') {
+                throw new Error(`[${options.tag}] Expected options.dimensions.height to be a number`);
+            }
+        }
         // The tag name of the component. Used by some drivers (e.g. angular) to turn the component into an html element,
         // e.g. <my-component>
 
@@ -56,7 +58,7 @@ export class Component {
 
         // The dimensions of the component, e.g. { width: 500, height: 200 }
 
-        this.dimensions = options.dimensions;
+        this.dimensions = options.dimensions || {};
 
         // The default environment we should render to if none is specified in the parent
 
@@ -178,20 +180,7 @@ export class Component {
         if (!options.tag || !options.tag.match(/^[a-z0-9-]+$/)) {
             throw new Error(`Invalid options.tag: ${options.tag}`);
         }
-
-    /*    if (!options.dimensions || !(typeof options.dimensions === 'object')) {
-            throw new Error(`[${options.tag}] Expected options.dimensions to be an object`);
-        }
-    */
         
-        if (typeof options.dimensions.width !== 'number') {
-            throw new Error(`[${options.tag}] Expected options.dimensions.width to be a number`);
-        }
-
-        if (typeof options.dimensions.height !== 'number') {
-            throw new Error(`[${options.tag}] Expected options.dimensions.height to be a number`);
-        }
-
         if (options.props && !(typeof options.props === 'object')) {
             throw new Error(`[${options.tag}] Expected options.props to be an object`);
         }

--- a/src/component/parent.js
+++ b/src/component/parent.js
@@ -143,6 +143,15 @@ let RENDER_DRIVERS = {
             this.iframe.style.top = pos.y;
             this.iframe.style.borderRadius = '10px';
 
+            if (this.component.dimensions.width === undefined && this.component.dimensions.height === undefined) {
+                this.iframe.style.left = 0;
+                this.iframe.style.top = 0;
+                this.iframe.style.borderRadius = '0px';
+                this.iframe.height = '100%';
+                this.iframe.width = '100%';
+                this.iframe.style.position = 'fixed';
+            }
+
             return this;
         },
 

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -39,13 +39,6 @@ export function getElement(id) {
 
 export function popup(url, options) {
 
-    // Condition for when dimensions (optional) for pop-up not specified
-    if(options.width === 0)
-    {
-        let win = window.open(url, options.name);
-        return win;
-    }
-
     let win = window.open(url, options.name, Object.keys(options).map((key) => {
 
         if (!options[key]) {

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -39,6 +39,13 @@ export function getElement(id) {
 
 export function popup(url, options) {
 
+    // Condition for when dimensions (optional) for pop-up not specified
+    if(options.width === 0)
+    {
+        let win = window.open(url, options.name);
+        return win;
+    }
+
     let win = window.open(url, options.name, Object.keys(options).map((key) => {
 
         if (!options[key]) {

--- a/test/component.js
+++ b/test/component.js
@@ -142,3 +142,15 @@ export var testComponent3 = xcomponent.create({
         lightbox: true
     }
 });
+
+export var testComponent4 = xcomponent.create({
+
+    tag: 'test-component4',
+    url: '/base/test/child.htm',
+
+    envUrls: {
+        dev: '/base/test/child.htm?devenv=true'
+    }
+});
+
+

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@ import xcomponent from 'src/index';
 import postRobot from 'post-robot/src';
 import { SyncPromise as Promise } from 'sync-browser-mocks/src/promise';
 
-import { testComponent, testComponent3 } from './component';
+import { testComponent, testComponent3, testComponent4 } from './component';
 import { loadScript, once, b64encode } from 'src/lib';
 import { CONTEXT_TYPES } from 'src/constants';
 
@@ -26,6 +26,21 @@ describe('basic xcomponent rendering', function() {
 
         component = testComponent.init({
             onEnter: done
+        }).renderLightbox();
+
+        postRobot.once('init', () => 'attachTestComponent');
+    });
+
+    it('should enter a component rendered as a lightbox with no dimensions', function(done) {
+
+        component = testComponent4.init({
+            onEnter: function() {
+                if (!(window.innerWidth === this.window.innerWidth && window.innerHeight === this.window.innerHeight)) {
+                    throw new Error('The parent and child window dimensions do not match'+'|'+ window.innerWidth);
+                } else {
+                    done();
+                }
+            }
         }).renderLightbox();
 
         postRobot.once('init', () => 'attachTestComponent');


### PR DESCRIPTION
You can test this feature by commenting out dimensions property for xcomponent.create in checkout-components.
Logic??
1. Add a flag of 0 for both width and height if dimensions property not specified in checkout.js.
2. Check if options.dimensions == object? If not, give it (width, height) a number 0.
3. In dom.js changed the popup function: check if with,height==0. If yes, do window,open without passing any size for the window so as to have a new tab open.

