### PR TITLE
Update index.js to allow resizing when not using autoresize

### DIFF
--- a/src/component/parent/index.js
+++ b/src/component/parent/index.js
@@ -662,7 +662,7 @@ export class ParentComponent extends BaseComponent {
 
             [ POST_MESSAGE.RESIZE ](source, data) {
 
-                if (this.driver.allowResize && this.component.autoResize) {
+                if (this.driver.allowResize) {
                     return this.resize(data.width, data.height);
                 }
             },


### PR DESCRIPTION
The auto resize does not always work the best especially when shrinking/growing width of the browser. We would however like to tell the iframe to resize itself in certain scenarios without having to have this autoResize functionally.