### PR TITLE
use context as getRenderContext argument

### DIFF
--- a/src/component/component/index.js
+++ b/src/component/component/index.js
@@ -410,7 +410,7 @@ export class Component<P> extends BaseComponent<P> {
     */
 
     init(props : (PropsType & P), context : ?string, element : ElementRefType) : ParentComponent<P> {
-        return new ParentComponent(this, this.getRenderContext(context), { props });
+        return new ParentComponent(this, this.getRenderContext(context, element), { props });
     }
 
 

--- a/test/tests/error.js
+++ b/test/tests/error.js
@@ -72,13 +72,6 @@ describe('xcomponent error cases', () => {
         });
     });
 
-    it('should try to render a component with a specified element when iframe mode is not supported', done => {
-
-        testComponent3.render({}, document.body).catch(() => {
-            done();
-        });
-    });
-
     it('should try to render to when iframe is the only available option but no element is passed', done => {
 
         let originalDefaultContext = testComponent.defaultContext;
@@ -95,6 +88,87 @@ describe('xcomponent error cases', () => {
             testComponent.contexts = originalContexts;
             done();
         });
+    });
+
+    it('should try to render a popup when an element selector is specified', done => {
+        let originalDefaultContext = testComponent.defaultContext;
+        let originalContexts = testComponent.contexts;
+
+        delete testComponent.defaultContext;
+        testComponent.contexts = {
+            popup: true,
+            iframe: false
+        };
+
+        testComponent.render(null, 'moo').then(() => {
+            done('Expected an error to be thrown');
+        }).catch(() => {
+            testComponent.defaultContext = originalDefaultContext;
+            testComponent.contexts = originalContexts;
+
+            done();
+        });
+    });
+
+    it('should try to render a popup when an element selector is specified using renderTo', done => {
+        let originalDefaultContext = testComponent.defaultContext;
+        let originalContexts = testComponent.contexts;
+
+        delete testComponent.defaultContext;
+        testComponent.contexts = {
+            popup: true,
+            iframe: false
+        };
+
+        testComponent.renderTo(window, null, 'moo').then(() => {
+            done('Expected an error to be thrown');
+        }).catch(() => {
+            testComponent.defaultContext = originalDefaultContext;
+            testComponent.contexts = originalContexts;
+
+            done();
+        });
+    });
+
+    it('should throw an error if the component does not have a suitable context configured', done => {
+        let originalDefaultContext = testComponent.defaultContext;
+        let originalContexts = testComponent.contexts;
+
+        delete testComponent.defaultContext;
+        testComponent.contexts = {
+            popup: false,
+            iframe: false
+        };
+
+        testComponent.render(null).then(() => {
+            done('Expected an error to be thrown');
+        }).catch(() => {
+            testComponent.defaultContext = originalDefaultContext;
+            testComponent.contexts = originalContexts;
+
+            done();
+        });
+    });
+
+    it('should throw an error if the context specified is not accepted by the component config', done => {
+        let originalDefaultContext = testComponent.defaultContext;
+        let originalContexts = testComponent.contexts;
+
+        delete testComponent.defaultContext;
+        testComponent.contexts = {
+            popup: false,
+            iframe: true
+        };
+
+        try {
+            testComponent.init(null, 'popup', 'moo');
+            done('expected error to be thrown');
+        } catch (e) {
+            testComponent.defaultContext = originalDefaultContext;
+            testComponent.contexts = originalContexts;
+
+            done();
+        }
     });
 
     it('should call onclose when a popup is closed by someone other than xcomponent', done => {

--- a/test/tests/happy.js
+++ b/test/tests/happy.js
@@ -195,6 +195,19 @@ describe('xcomponent happy cases', () => {
         });
     });
 
+    it('should try to render to defaultContext iframe using renderTo', done => {
+        
+        let originalDefaultContext = testComponent.defaultContext;
+        testComponent.defaultContext = 'iframe';
+
+        testComponent.renderTo(window, {
+            onEnter() {
+                testComponent.defaultContext = originalDefaultContext;
+                done();
+            }
+        });
+    });
+
     it('should try to render to defaultContext popup', done => {
 
         let originalDefaultContext = testComponent.defaultContext;
@@ -244,6 +257,31 @@ describe('xcomponent happy cases', () => {
                 testComponent.defaultContext = originalDefaultContext;
                 testComponent.contexts = originalContexts;
                 done();
+            }
+        });
+    });
+
+    it('should try to render to iframe, when both iframe and popup are supported contexts', done => {
+        
+        let originalDefaultContext = testComponent.defaultContext;
+        let originalContexts = testComponent.contexts;
+
+        delete testComponent.defaultContext;
+        testComponent.contexts = {
+            popup: true,
+            iframe: true
+        };
+
+        testComponent.render({
+            onEnter() {
+                try {
+                    assert.equal(this.context, 'iframe');
+                    testComponent.defaultContext = originalDefaultContext;
+                    testComponent.contexts = originalContexts;
+                    done();
+                } catch (e) {
+                    done(e);
+                }
             }
         });
     });


### PR DESCRIPTION
Fix for issue #131.

`getRenderContext()` seemed to be used inconsistently. If an element reference, or any value, was passed, `CONTEXT_TYPE.IFRAME` was validated, regardless of whether the component definition specified a context.

It looks like a work around was put in place for `Component` functions like `renderIframe` and `renderPopup`, where `validateRenderContext(context)` was called directly, and the `CONTEXT_TYPE` was hard-coded to the `ParentComponent` constructor arguments. I refactored these functions to be more consistent, so validation is handled correctly by `getRenderContext(context)`