### PR TITLE
Enhance `url` description

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -31,6 +31,12 @@ url: {
     live: 'https://my-live-site.com/mycomponent'
 }
 ```
+Note: If the map-syntax is used for `url`, the rendered component can override the `defaultEnv` at runtime like so:
+```javascript
+MyComponent.render({
+env: 'local'
+}, '#container')
+```
 
 #### dimensions `{ width : string, height : string }`
 
@@ -455,6 +461,8 @@ url: {
 
 defaultEnv: 'live'
 ```
+
+Note: See `url` definition for note on overriding defaultEnv.
 
 #### domain `string | { env : string }`
 


### PR DESCRIPTION
The API docs do a good job of explaining how to use map-syntax for the url. However, they don't mention how to override the `defaultEnv`. Without that information the user is left having to change the `defaultEnv` variable every time they want to change the environment. I added some notes based on @bluepnume's suggestion in #142.