### PR TITLE
Make it optional to include IE bridge support when importing as module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 
-if (process.env.XCOMPONENT_EXCLUDE_IE_BRIDGE) {
+if (process.env.XCOMPONENT_FRAME_ONLY) {
   module.exports = require('./dist/xcomponent.frame');
   module.exports.default = module.exports;
 } else {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,8 @@
 
-module.exports = require('./dist/xcomponent');
-module.exports.default = module.exports;
+if (process.env.XCOMPONENT_EXCLUDE_IE_BRIDGE) {
+  module.exports = require('./dist/xcomponent.frame');
+  module.exports.default = module.exports;
+} else {
+  module.exports = require('./dist/xcomponent');
+  module.exports.default = module.exports;
+}


### PR DESCRIPTION
Solves: https://github.com/krakenjs/xcomponent/issues/152

When included by webpack you can choose if you want to include with or without bridge support the same way react does it (https://github.com/facebook/react/blob/master/packages/react/npm/index.js):

```
plugins: [
    new webpack.DefinePlugin({
      'process.env': {
        'NODE_ENV': JSON.stringify(process.env.NODE_ENV),
        'XCOMPONENT_EXCLUDE_IE_BRIDGE': true
      }
    })
  ]
```